### PR TITLE
ensure user HOME directory exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -370,7 +370,7 @@ function fillInHome(opts, callback) {
       opts.env = opts.env || {};
       opts.env.HOME = user && user.homedir || process.env.HOME;
       opts.cwd = opts.cwd || opts.env.HOME;
-      // opts.dirs.push(opts.cwd);
+      opts.dirs.push(opts.cwd);
     }
     if (opts.dryRun) {
       err = null;


### PR DESCRIPTION
If the user already exists it doesn't always mean their HOME directory
exits since it may have been mistakenly deleted during a manual
reinstall.

Connect to #10